### PR TITLE
feat(import): allow to pass a custom plugin

### DIFF
--- a/features/import.feature
+++ b/features/import.feature
@@ -27,6 +27,10 @@ Feature: CLI - Import command
       """
       -c, --config <object>
       """
+    Then the output should contain:
+      """
+      --plugin <path>
+      """
 
   Scenario: Show missing option error
     When I run `sphere import -p foo`
@@ -131,4 +135,31 @@ Feature: CLI - Import command
     Then the output should contain:
       """
       "successfullImports": 2
+      """
+
+  Scenario: Import stock by using a custom plugin
+    Given a file named "stocks.json" with:
+      """
+      {
+        "stocks": [
+          {
+            "sku": "<id-a>",
+            "quantityOnStock": 10
+          },
+          {
+            "sku": "<id-b>",
+            "quantityOnStock": 20
+          }
+        ]
+      }
+      """
+    When I run `sphere import --plugin $(pwd)/../plugins/custom-stock.js -f stocks.json`
+    Then the exit status should be 0
+    Then the output should contain:
+      """
+      quantityOnStock: 10
+      """
+    Then the output should contain:
+      """
+      Finished
       """

--- a/lib/commands/import.js
+++ b/lib/commands/import.js
@@ -120,10 +120,11 @@ export default class ImportCommand extends Command {
         'the path to a JSON file where to read from')
       .option('-b, --batch <n>',
         'how many chunks should be processed in batches (default: 5)',
-        parseInt, 5)
+        num => parseInt(num, 10), 5)
       .option('-c, --config <object>',
         'a JSON object as a string to be passed to the related library, ' +
         'usually containing specific configuration options')
+      .option('--plugin <path>', 'the absolute path to a custom plugin')
       .on('--help', help)
       .parse(argv)
 
@@ -131,17 +132,27 @@ export default class ImportCommand extends Command {
       this.program.help()
 
     const options = pick(this.program,
-      'project', 'type', 'from', 'batch', 'config')
-    this._validateOptions(options, 'type')
+      'project', 'type', 'from', 'batch', 'config', 'plugin')
+    if (!options.plugin)
+      this._validateOptions(options, 'type')
     return this._preProcess(options)
   }
 
   _process (options) {
+    if (options.plugin)
+      return this._processWithPlugin(options)
+
     const service = serviceMapping[options.type]
     if (service)
       return this._stream(...service(options))
 
     return this._die(`Unsupported type: ${options.type}`)
+  }
+
+  _processWithPlugin (options) {
+    const { plugin } = options
+    const service = require(plugin)
+    return this._stream(...service(options))
   }
 
   _stream (options, jsonPath, processFn, finishFn) {

--- a/plugins/custom-stock.js
+++ b/plugins/custom-stock.js
@@ -1,0 +1,17 @@
+module.exports = function customStock (options) {
+  const processFn = processStream
+  return [ options, 'stocks.*', processFn, finishFn ]
+}
+
+function processStream (data, next) {
+  return new Promise(function (/* resolve, reject */) {
+    setTimeout(function () {
+      console.log(data)
+      next()
+    }, 500)
+  })
+}
+
+function finishFn () {
+  return console.log('Finished')
+}

--- a/test/commands/import.spec.js
+++ b/test/commands/import.spec.js
@@ -33,6 +33,7 @@ describe('ImportCommand', () => {
     command.program.options[2].flags.should.equal('-f, --from <path>')
     command.program.options[3].flags.should.equal('-b, --batch <n>')
     command.program.options[4].flags.should.equal('-c, --config <object>')
+    command.program.options[5].flags.should.equal('--plugin <path>')
     command.program.should.not.have.property('project')
     command.program.should.not.have.property('type')
     command.program.should.not.have.property('from')

--- a/test/commands/import.spec.js
+++ b/test/commands/import.spec.js
@@ -27,7 +27,7 @@ describe('ImportCommand', () => {
     command.program.name.should.be.a.Function
     command.program.name().should.equal('sphere-import')
     command.program.commands.should.have.lengthOf(0)
-    command.program.options.should.have.lengthOf(5)
+    command.program.options.should.have.lengthOf(6)
     command.program.options[0].flags.should.equal('-p, --project <key>')
     command.program.options[1].flags.should.equal('-t, --type <name>')
     command.program.options[2].flags.should.equal('-f, --from <path>')


### PR DESCRIPTION
## Summary
Introduce an option to execute custom plugins for the `import` command.

## Description
Sometime the default importers do not meet specific customer requirements and you end up writing your own importer from scratch.

In such cases, you can write a custom plugin to process and let the cli do the dirty work (streaming). When running the command, simply provide the path to your custom plugin script.

```bash
# using the `custom-stock.js` example in the plugins folder
$ sphere import --plugin $(pwd)/plugins/custom-stock.js -f stocks.json
```

The plugin must export a function which returns specific objects:

```js
export default function myCustomPlugin (options) {
  // `options` are the command options
  return [
    options,
    // This is the parsing path used by the JSON stream, following the schema
    // https://github.com/sphereio/sphere-node-cli#sphere-import
    'stocks.*',
    // The function to process the stream (see below)
    processFn,
    // The function called when the import is finished
    finishFn
  ]
}

// `data` is an array of the parsed chunks
// `next` is the function that should be called to get the next array of chunks
function processFn (data, next) {
  // return a Promise
  return new Promise(function (/* resolve, reject */) {
    setTimeout(function () {
      console.log(data)
      next()
    }, 500)
  })
}
```

## Reviewers
- [x] @PhilippSpo has approved the PR

## Tests
- [x] Unit tests
- [x] Features