### PR TITLE
Fix products delimiter and total count in products export

### DIFF
--- a/lib/commands/export.js
+++ b/lib/commands/export.js
@@ -61,37 +61,46 @@ export default class ExportCommand extends Command {
 
   _stream (options, processFn, finishFn) {
     let isFirst = true
-    let prefix = ','
-    const outputStream = fs.createWriteStream(
-      options.output, { encoding: 'utf-8' })
-    outputStream.on('error', error =>
-      this._die('Problem on output stream.\n', error))
-    outputStream.on('finish', () => fs.appendFileSync(options.output, ']}'))
+    let total = 0
+    let prefix = ''
 
-    processFn(payload => {
-      if (isFirst) {
-        outputStream.write(
-          `{"total": ${payload.body.total}, "${pluralize(options.type)}": [`)
-        prefix = ''
-        isFirst = false
-      }
+    return new Promise((resolve) => {
+      const outputStream = fs.createWriteStream(
+        options.output, { encoding: 'utf-8' })
 
-      return new Promise(resolve => {
+      outputStream.on('error', error =>
+        this._die('Problem on output stream.\n', error))
+
+      outputStream.on('finish', () => {
+        fs.appendFileSync(options.output, `], "total": ${total}}`)
+        finishFn()
+        resolve()
+      })
+
+      processFn(payload => {
+        total += payload.body.results.length
+
+        if (isFirst) {
+          outputStream.write(
+            `{"${pluralize(options.type)}": [`)
+          isFirst = false
+        }
+
         payload.body.results.forEach(chunk => {
           const chunkString = options.pretty
             ? JSON.stringify(chunk, null, 2)
             : JSON.stringify(chunk)
           outputStream.write(prefix + chunkString)
+          prefix = ','
         })
         process.stdout.write('.')
-        return resolve()
+        return Promise.resolve()
       })
+        .then(() => {
+          outputStream.end()
+          process.stdout.write('\n')
+        })
+        .catch(e => this._die('Problem when processing stream.\n', e))
     })
-    .then(() => {
-      outputStream.end()
-      process.stdout.write('\n')
-      return finishFn()
-    })
-    .catch(e => this._die('Problem when processing stream.\n', e))
   }
 }


### PR DESCRIPTION
Fixes #53
- Adds a comma delimiter between all (JSON serialized) products
- Fix total count in final export

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
