### PR TITLE
chore: update dep orders-update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -191,9 +191,9 @@
       "integrity": "sha512-/zNwoaM7K8xRPV7hCupii7YhPgYinCNz16YERbgAy8gZUVNZ5DDx+QdrVgnwpAmKm5pTT/CimRMiFjHdw2H5Wg=="
     },
     "@commercetools/orders-update": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@commercetools/orders-update/-/orders-update-2.2.1.tgz",
-      "integrity": "sha512-vNy9om9cOxkqVBtZhr7NYMdkgcTUAZeAb0ayFdWIMKVlmNF4sskNU0ZOboIMyntENZp3RPJh4G+YsCaIFujFVw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@commercetools/orders-update/-/orders-update-2.2.2.tgz",
+      "integrity": "sha512-ddcstq1SDU0VJGvGm/5FgUrTbmGM+FssqPnCvTBVE7z6JS9cR2ti7oFVMcnvYtsFigwlQbQ5JAM5Q250Lf4CxA==",
       "requires": {
         "ajv": "^4.9.0",
         "babel-plugin-transform-object-rest-spread": "^6.22.0",
@@ -13104,7 +13104,7 @@
     },
     "samsam": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
       "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc="
     },
     "sax": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@commercetools/custom-objects-importer": "^1.0.4",
     "@commercetools/discount-code-importer": "^1.0.40",
-    "@commercetools/orders-update": "^2.2.1",
+    "@commercetools/orders-update": "^2.2.2",
     "@commercetools/state-importer": "^1.0.16",
     "JSONStream": "^1.3.4",
     "commander": "github:emmenko/commander.js#patch-help",


### PR DESCRIPTION
#### Summary
Updates dependency `orders-update` to `v2.2.2` which adds a required flag to lineItem.id property.

https://github.com/commercetools/orders-update/releases/tag/v2.2.2